### PR TITLE
Change "on_strike" message

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <resources>
     <string name="app_name">Transport Strikes Ireland</string>
-    <string name="on_strike">The feckers are on strike today! %s</string>
+    <string name="on_strike">There is a strike today! %s</string>
     <string name="not_on_strike">Good news, no strikes today!</string>
     <string name="on_strike_tomorrow">Not on strike today, but are tomorrow!</string>
     <string name="fab_up">Congrats, that\'s how a luas driver goes forward!</string>


### PR DESCRIPTION
I think it's a bit more professional to just say there's a strike without referring to the strikers themselves as 'feckers'. I know it's probably tongue-in-cheek, but still.
